### PR TITLE
Avoid reaching the same class multiple times

### DIFF
--- a/src/main/scala/com/mpc/scalats/core/ScalaParser.scala
+++ b/src/main/scala/com/mpc/scalats/core/ScalaParser.scala
@@ -10,7 +10,7 @@ object ScalaParser {
   import ScalaModel._
 
   def parseCaseClasses(caseClassTypes: List[Type]): List[CaseClass] = {
-    caseClassTypes.flatMap(getInvolvedTypes(Set.empty)).filter(isCaseClass).distinct.map(parseCaseClass)
+    caseClassTypes.flatMap(getInvolvedTypes(Set.empty)).filter(isCaseClass).distinct.map(parseCaseClass).distinct
   }
 
   private def parseCaseClass(caseClassType: Type) = {


### PR DESCRIPTION
When using a List of class to seed the plugin, common involved types would get generated once per class.