### PR TITLE
Config option to prefix interfaces with "I" prefix

### DIFF
--- a/src/main/scala/com/mpc/scalats/configuration/Config.scala
+++ b/src/main/scala/com/mpc/scalats/configuration/Config.scala
@@ -10,5 +10,6 @@ case class Config(
                  emitClasses: Boolean = false,
                  optionToNullable: Boolean = true,
                  optionToUndefined: Boolean = false,
-                 outputStream : Option[PrintStream] = None
+                 outputStream : Option[PrintStream] = None,
+                 prependIPrefix: Boolean = true
                  )

--- a/src/main/scala/com/mpc/scalats/configuration/Config.scala
+++ b/src/main/scala/com/mpc/scalats/configuration/Config.scala
@@ -6,10 +6,10 @@ import java.io.PrintStream
   * Created by Milosz on 09.12.2016.
   */
 case class Config(
-                 emitInterfaces: Boolean = true,
-                 emitClasses: Boolean = false,
-                 optionToNullable: Boolean = true,
-                 optionToUndefined: Boolean = false,
-                 outputStream : Option[PrintStream] = None,
-                 prependIPrefix: Boolean = true
-                 )
+    emitInterfaces: Boolean = true,
+    emitClasses: Boolean = false,
+    optionToNullable: Boolean = true,
+    optionToUndefined: Boolean = false,
+    outputStream: Option[PrintStream] = None,
+    prependIPrefix: Boolean = true
+)

--- a/src/main/scala/com/mpc/scalats/core/Compiler.scala
+++ b/src/main/scala/com/mpc/scalats/core/Compiler.scala
@@ -7,7 +7,6 @@ import com.mpc.scalats.core.TypeScriptModel.{ClassConstructor, ClassConstructorP
   * Created by Milosz on 09.06.2016.
   */
 object Compiler {
-
   def compile(scalaClasses: List[ScalaModel.CaseClass])(implicit config: Config): List[TypeScriptModel.Declaration] = {
     scalaClasses flatMap { scalaClass =>
       val interface = if (config.emitInterfaces) List(compileInterface(scalaClass)) else List.empty
@@ -18,8 +17,8 @@ object Compiler {
 
   private def compileInterface(scalaClass: ScalaModel.CaseClass)(implicit config: Config) = {
     TypeScriptModel.InterfaceDeclaration(
-      s"I${scalaClass.name}",
-      scalaClass.members map { scalaMember =>
+      buildInterfaceName(scalaClass.name),
+      scalaClass.members.map { scalaMember =>
         TypeScriptModel.Member(
           scalaMember.name,
           compileTypeRef(scalaMember.typeRef, inInterfaceContext = true)
@@ -27,6 +26,14 @@ object Compiler {
       },
       typeParams = scalaClass.params
     )
+  }
+
+  private def buildInterfaceName(name: String)(implicit config: Config) = {
+    if (config.prependIPrefix) {
+      s"I$name"
+    } else {
+      name
+    }
   }
 
   private def compileClass(scalaClass: ScalaModel.CaseClass)(implicit config: Config) = {
@@ -63,7 +70,7 @@ object Compiler {
     case ScalaModel.SeqRef(innerType) =>
       TypeScriptModel.ArrayRef(compileTypeRef(innerType, inInterfaceContext))
     case ScalaModel.CaseClassRef(name, typeArgs) =>
-      val actualName = if (inInterfaceContext) s"I$name" else name
+      val actualName = if (inInterfaceContext) buildInterfaceName(name) else name
       TypeScriptModel.CustomTypeRef(actualName, typeArgs.map(compileTypeRef(_, inInterfaceContext)))
     case ScalaModel.DateRef =>
       TypeScriptModel.DateRef

--- a/src/main/scala/com/mpc/scalats/core/Compiler.scala
+++ b/src/main/scala/com/mpc/scalats/core/Compiler.scala
@@ -9,8 +9,11 @@ import com.mpc.scalats.core.TypeScriptModel.{ClassConstructor, ClassConstructorP
 object Compiler {
   def compile(scalaClasses: List[ScalaModel.CaseClass])(implicit config: Config): List[TypeScriptModel.Declaration] = {
     scalaClasses flatMap { scalaClass =>
-      val interface = if (config.emitInterfaces) List(compileInterface(scalaClass)) else List.empty
-      val clazz = if (config.emitClasses) List(compileClass(scalaClass)) else List.empty
+      val interface =
+        if (config.emitInterfaces) List(compileInterface(scalaClass))
+        else List.empty
+      val clazz =
+        if (config.emitClasses) List(compileClass(scalaClass)) else List.empty
       interface ++ clazz
     }
   }
@@ -29,11 +32,8 @@ object Compiler {
   }
 
   private def buildInterfaceName(name: String)(implicit config: Config) = {
-    if (config.prependIPrefix) {
-      s"I$name"
-    } else {
-      name
-    }
+    val prefix = if (config.prependIPrefix) "I" else ""
+    s"${prefix}${name}"
   }
 
   private def compileClass(scalaClass: ScalaModel.CaseClass)(implicit config: Config) = {
@@ -53,10 +53,9 @@ object Compiler {
   }
 
   private def compileTypeRef(
-                              scalaTypeRef: ScalaModel.TypeRef,
-                              inInterfaceContext: Boolean
-                            )
-                            (implicit config: Config): TypeScriptModel.TypeRef = scalaTypeRef match {
+      scalaTypeRef: ScalaModel.TypeRef,
+      inInterfaceContext: Boolean
+  )(implicit config: Config): TypeScriptModel.TypeRef = scalaTypeRef match {
     case ScalaModel.IntRef =>
       TypeScriptModel.NumberRef
     case ScalaModel.LongRef =>
@@ -70,24 +69,35 @@ object Compiler {
     case ScalaModel.SeqRef(innerType) =>
       TypeScriptModel.ArrayRef(compileTypeRef(innerType, inInterfaceContext))
     case ScalaModel.CaseClassRef(name, typeArgs) =>
-      val actualName = if (inInterfaceContext) buildInterfaceName(name) else name
-      TypeScriptModel.CustomTypeRef(actualName, typeArgs.map(compileTypeRef(_, inInterfaceContext)))
+      val actualName =
+        if (inInterfaceContext) buildInterfaceName(name) else name
+      TypeScriptModel.CustomTypeRef(
+        actualName,
+        typeArgs.map(compileTypeRef(_, inInterfaceContext)))
     case ScalaModel.DateRef =>
       TypeScriptModel.DateRef
     case ScalaModel.DateTimeRef =>
       TypeScriptModel.DateTimeRef
     case ScalaModel.TypeParamRef(name) =>
       TypeScriptModel.TypeParamRef(name)
-    case ScalaModel.OptionRef(innerType) if config.optionToNullable && config.optionToUndefined =>
-      TypeScriptModel.UnionType(TypeScriptModel.UnionType(compileTypeRef(innerType, inInterfaceContext), NullRef), UndefinedRef)
+    case ScalaModel.OptionRef(innerType)
+        if config.optionToNullable && config.optionToUndefined =>
+      TypeScriptModel.UnionType(
+        TypeScriptModel.UnionType(compileTypeRef(innerType, inInterfaceContext),
+                                  NullRef),
+        UndefinedRef)
     case ScalaModel.OptionRef(innerType) if config.optionToNullable =>
-      TypeScriptModel.UnionType(compileTypeRef(innerType, inInterfaceContext), NullRef)
+      TypeScriptModel.UnionType(compileTypeRef(innerType, inInterfaceContext),
+                                NullRef)
     case ScalaModel.MapRef(kT, vT) =>
-      TypeScriptModel.MapType(compileTypeRef(kT, inInterfaceContext), compileTypeRef(vT, inInterfaceContext))
+      TypeScriptModel.MapType(compileTypeRef(kT, inInterfaceContext),
+                              compileTypeRef(vT, inInterfaceContext))
     case ScalaModel.UnionRef(i, i2) =>
-      TypeScriptModel.UnionType(compileTypeRef(i, inInterfaceContext), compileTypeRef(i2, inInterfaceContext))
+      TypeScriptModel.UnionType(compileTypeRef(i, inInterfaceContext),
+                                compileTypeRef(i2, inInterfaceContext))
     case ScalaModel.OptionRef(innerType) if config.optionToUndefined =>
-      TypeScriptModel.UnionType(compileTypeRef(innerType, inInterfaceContext), UndefinedRef)
+      TypeScriptModel.UnionType(compileTypeRef(innerType, inInterfaceContext),
+                                UndefinedRef)
     case ScalaModel.UnknownTypeRef(_) =>
       TypeScriptModel.StringRef
   }

--- a/src/main/scala/com/mpc/scalats/sbt/TypeScriptGeneratorPlugin.scala
+++ b/src/main/scala/com/mpc/scalats/sbt/TypeScriptGeneratorPlugin.scala
@@ -16,9 +16,14 @@ object TypeScriptGeneratorPlugin extends AutoPlugin {
 
     val emitInterfaces = settingKey[Boolean]("Generate interface declarations")
     val emitClasses = settingKey[Boolean]("Generate class declarations")
-    val optionToNullable = settingKey[Boolean]("Option types will be compiled to 'type | null'")
-    val optionToUndefined = settingKey[Boolean]("Option types will be compiled to 'type | undefined'")
-    val outputFile  = settingKey[Option[PrintStream]]("Print stream to write. Defaults to Console.out")
+    val optionToNullable =
+      settingKey[Boolean]("Option types will be compiled to 'type | null'")
+    val optionToUndefined =
+      settingKey[Boolean]("Option types will be compiled to 'type | undefined'")
+    val outputFile = settingKey[Option[PrintStream]](
+      "Print stream to write. Defaults to Console.out")
+    val prependIPrefix =
+      settingKey[Boolean]("Whether to prefix interface names with I")
   }
 
   import autoImport._
@@ -30,7 +35,8 @@ object TypeScriptGeneratorPlugin extends AutoPlugin {
         (emitClasses in generateTypeScript).value,
         (optionToNullable in generateTypeScript).value,
         (optionToUndefined in generateTypeScript).value,
-        (outputFile in generateTypeScript).value
+        (outputFile in generateTypeScript).value,
+        (prependIPrefix in generateTypeScript).value
       )
 
       val args = spaceDelimited("").parsed
@@ -44,7 +50,8 @@ object TypeScriptGeneratorPlugin extends AutoPlugin {
     emitClasses in generateTypeScript := false,
     optionToNullable in generateTypeScript := true,
     optionToUndefined in generateTypeScript := false,
-    outputFile in generateTypeScript := None
+    outputFile in generateTypeScript := None,
+    prependIPrefix := false
   )
 
 }


### PR DESCRIPTION
This PR adds a configuration option `prependIPrefix` which enables or disables interfaces getting an `I` prepended to their name (i.e. `ISomething` vs `Something`). The option is set to `true` by default to preserve previous behavior ("I" was prepended by default).

There are some lingering formatting tweaks; let me know those bother you and I can strip those out if you'd like.

Resolves #4 